### PR TITLE
Update Nucleus: Media

### DIFF
--- a/library/src/Nucleus/Media/ApplicationEvent.c
+++ b/library/src/Nucleus/Media/ApplicationEvent.c
@@ -15,7 +15,7 @@ destruct
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_ApplicationEvent_Class *dispatch

--- a/library/src/Nucleus/Media/AudioSystem.c
+++ b/library/src/Nucleus/Media/AudioSystem.c
@@ -6,14 +6,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Library_Export,
                             Nucleus_Media_AudioSystem,
                             Nucleus_Object)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_AudioSystem_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_AudioSystem_Class *dispatch

--- a/library/src/Nucleus/Media/AudioSystemFactory.c
+++ b/library/src/Nucleus/Media/AudioSystemFactory.c
@@ -9,7 +9,7 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Library_Export,
                             Nucleus_Media_AudioSystemFactory,
                             Nucleus_Object)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_AudioSystemFactory_Class *dispatch
@@ -20,7 +20,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_AudioSystemFactory_Class *dispatch

--- a/library/src/Nucleus/Media/Event.c
+++ b/library/src/Nucleus/Media/Event.c
@@ -9,21 +9,21 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Library_Export,
                             Nucleus_Event,
                             Nucleus_Object)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Event_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Event_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_NonNull(1) static Nucleus_Status
+Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
 destruct
     (
         Nucleus_Event *event

--- a/library/src/Nucleus/Media/KeyboardKeyEvent.c
+++ b/library/src/Nucleus/Media/KeyboardKeyEvent.c
@@ -15,14 +15,14 @@ destruct
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_KeyboardKeyEvent_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_KeyboardKeyEvent_Class *dispatch

--- a/library/src/Nucleus/Media/MouseButtonEvent.c
+++ b/library/src/Nucleus/Media/MouseButtonEvent.c
@@ -15,14 +15,14 @@ destruct
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_MouseButtonEvent_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_MouseButtonEvent_Class *dispatch

--- a/library/src/Nucleus/Media/MousePointerEvent.c
+++ b/library/src/Nucleus/Media/MousePointerEvent.c
@@ -15,14 +15,14 @@ destruct
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_MousePointerEvent_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_MousePointerEvent_Class *dispatch

--- a/library/src/Nucleus/Media/Plugin.c
+++ b/library/src/Nucleus/Media/Plugin.c
@@ -41,7 +41,7 @@ destruct
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_Class *dispatch
@@ -54,7 +54,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_Class *dispatch

--- a/library/src/Nucleus/Media/VideoSystem.c
+++ b/library/src/Nucleus/Media/VideoSystem.c
@@ -6,14 +6,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Library_Export,
                             Nucleus_Media_VideoSystem,
                             Nucleus_Object)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_VideoSystem_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_VideoSystem_Class *dispatch

--- a/library/src/Nucleus/Media/VideoSystemFactory.c
+++ b/library/src/Nucleus/Media/VideoSystemFactory.c
@@ -9,7 +9,7 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Library_Export,
                             Nucleus_Media_VideoSystemFactory,
                             Nucleus_Object)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_VideoSystemFactory_Class *dispatch
@@ -20,7 +20,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_VideoSystemFactory_Class *dispatch

--- a/library/src/Nucleus/Media/VideoSystemWindow.c
+++ b/library/src/Nucleus/Media/VideoSystemWindow.c
@@ -5,14 +5,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Library_Export,
                             Nucleus_Media_VideoSystemWindow,
                             Nucleus_Object)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_VideoSystemWindow_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_VideoSystemWindow_Class *dispatch
@@ -37,7 +37,7 @@ constructSignals
 	return Nucleus_Status_Success;
 }
 
-Nucleus_NonNull(1) static Nucleus_Status
+Nucleus_AlwaysSucceed() Nucleus_NonNull(1) static Nucleus_Status
 destruct
     (
         Nucleus_Media_VideoSystemWindow *self

--- a/plugins/Direct3D/src/Nucleus.Media.Plugin.Direct3D/Plugin.c
+++ b/plugins/Direct3D/src/Nucleus.Media.Plugin.Direct3D/Plugin.c
@@ -76,7 +76,7 @@ getName
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_Direct3D_Plugin_Class *dispatch
@@ -88,7 +88,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_Direct3D_Plugin_Class *dispatch

--- a/plugins/Direct3D/src/Nucleus.Media.Plugin.Direct3D/VideoSystem.c
+++ b/plugins/Direct3D/src/Nucleus.Media.Plugin.Direct3D/VideoSystem.c
@@ -6,14 +6,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Plugin_Direct3D_Export,
                             Nucleus_Media_Plugin_Direct3D_VideoSystem,
                             Nucleus_Media_VideoSystem)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_Direct3D_VideoSystem_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_Direct3D_VideoSystem_Class *dispatch

--- a/plugins/Direct3D/src/Nucleus.Media.Plugin.Direct3D/VideoSystemFactory.c
+++ b/plugins/Direct3D/src/Nucleus.Media.Plugin.Direct3D/VideoSystemFactory.c
@@ -21,7 +21,7 @@ createSystem
         Nucleus_Media_VideoSystem **system
     );
     
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_Direct3D_VideoSystemFactory_Class *dispatch
@@ -32,7 +32,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_Direct3D_VideoSystemFactory_Class *dispatch

--- a/plugins/Direct3D/src/Nucleus.Media.Plugin.Direct3D/VideoSystemWindow.c
+++ b/plugins/Direct3D/src/Nucleus.Media.Plugin.Direct3D/VideoSystemWindow.c
@@ -7,14 +7,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Plugin_Direct3D_Export,
                             Nucleus_Media_Plugin_Direct3D_VideoSystemWindow,
                             Nucleus_Media_VideoSystemWindow)
     
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_Direct3D_VideoSystemWindow_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_Direct3D_VideoSystemWindow_Class *dispatch

--- a/plugins/OpenAL/src/Nucleus.Media.Plugin.OpenAL/AudioSystem.c
+++ b/plugins/OpenAL/src/Nucleus.Media.Plugin.OpenAL/AudioSystem.c
@@ -6,14 +6,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Plugin_OpenAL_Export,
                             Nucleus_Media_Plugin_OpenAL_AudioSystem,
                             Nucleus_Media_AudioSystem)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_OpenAL_AudioSystem_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_OpenAL_AudioSystem_Class *dispatch

--- a/plugins/OpenAL/src/Nucleus.Media.Plugin.OpenAL/AudioSystemFactory.c
+++ b/plugins/OpenAL/src/Nucleus.Media.Plugin.OpenAL/AudioSystemFactory.c
@@ -22,7 +22,7 @@ createSystem
         Nucleus_Media_AudioSystem **system
     );
     
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_OpenAL_AudioSystemFactory_Class *dispatch
@@ -33,7 +33,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_OpenAL_AudioSystemFactory_Class *dispatch

--- a/plugins/OpenAL/src/Nucleus.Media.Plugin.OpenAL/Plugin.c
+++ b/plugins/OpenAL/src/Nucleus.Media.Plugin.OpenAL/Plugin.c
@@ -76,7 +76,7 @@ getName
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_OpenAL_Plugin_Class *dispatch
@@ -88,7 +88,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_OpenAL_Plugin_Class *dispatch

--- a/plugins/OpenGL/plugin/src/Nucleus.Media.Plugin.OpenGL/Plugin.c
+++ b/plugins/OpenGL/plugin/src/Nucleus.Media.Plugin.OpenGL/Plugin.c
@@ -76,7 +76,7 @@ getName
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_OpenGL_Plugin_Class *dispatch
@@ -88,7 +88,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_OpenGL_Plugin_Class *dispatch

--- a/plugins/OpenGL/plugin/src/Nucleus.Media.Plugin.OpenGL/VideoSystem.c
+++ b/plugins/OpenGL/plugin/src/Nucleus.Media.Plugin.OpenGL/VideoSystem.c
@@ -6,14 +6,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Plugin_OpenGL_Export,
                             Nucleus_Media_Plugin_OpenGL_VideoSystem,
                             Nucleus_Media_VideoSystem)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_OpenGL_VideoSystem_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_OpenGL_VideoSystem_Class *dispatch

--- a/plugins/OpenGL/plugin/src/Nucleus.Media.Plugin.OpenGL/VideoSystemFactory.c
+++ b/plugins/OpenGL/plugin/src/Nucleus.Media.Plugin.OpenGL/VideoSystemFactory.c
@@ -21,7 +21,7 @@ createSystem
         Nucleus_Media_VideoSystem **system
     );
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_OpenGL_VideoSystemFactory_Class *dispatch
@@ -32,7 +32,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_OpenGL_VideoSystemFactory_Class *dispatch

--- a/plugins/OpenGL/plugin/src/Nucleus.Media.Plugin.OpenGL/VideoSystemWindow.c
+++ b/plugins/OpenGL/plugin/src/Nucleus.Media.Plugin.OpenGL/VideoSystemWindow.c
@@ -7,14 +7,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Plugin_OpenGL_Export,
                             Nucleus_Media_Plugin_OpenGL_VideoSystemWindow,
                             Nucleus_Media_VideoSystemWindow)
     
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_OpenGL_VideoSystemWindow_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_OpenGL_VideoSystemWindow_Class *dispatch

--- a/plugins/XAudio2/src/Nucleus.Media.Plugin.XAudio2/AudioSystem.c
+++ b/plugins/XAudio2/src/Nucleus.Media.Plugin.XAudio2/AudioSystem.c
@@ -5,14 +5,14 @@ Nucleus_ClassTypeDefinition(Nucleus_Media_Plugin_XAudio2_Export,
                             Nucleus_Media_Plugin_XAudio2_AudioSystem,
                             Nucleus_Media_AudioSystem)
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_XAudio2_AudioSystem_Class *dispatch
     )
 { return Nucleus_Status_Success; }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_XAudio2_AudioSystem_Class *dispatch

--- a/plugins/XAudio2/src/Nucleus.Media.Plugin.XAudio2/AudioSystemFactory.c
+++ b/plugins/XAudio2/src/Nucleus.Media.Plugin.XAudio2/AudioSystemFactory.c
@@ -22,7 +22,7 @@ createSystem
         Nucleus_Media_AudioSystem **system
     );
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_XAudio2_AudioSystemFactory_Class *dispatch
@@ -33,7 +33,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_XAudio2_AudioSystemFactory_Class *dispatch

--- a/plugins/XAudio2/src/Nucleus.Media.Plugin.XAudio2/Plugin.c
+++ b/plugins/XAudio2/src/Nucleus.Media.Plugin.XAudio2/Plugin.c
@@ -76,7 +76,7 @@ getName
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructDispatch
     (
         Nucleus_Media_Plugin_XAudio2_Plugin_Class *dispatch
@@ -88,7 +88,7 @@ constructDispatch
     return Nucleus_Status_Success;
 }
 
-Nucleus_AlwaysSucceed() Nucleus_NonNull() static Nucleus_Status
+Nucleus_NonNull() static Nucleus_Status
 constructSignals
     (
         Nucleus_Media_Plugin_XAudio2_Plugin_Class *dispatch


### PR DESCRIPTION
Update annotations for latest version of Nucleus: Object: As signals
constructors and dispatch constructors are not required to succceed
anymore, the Nucleus_AlwaysSucceed() annotation was removed from
them. The same annotation was missing at some object destructors,
which was fixed as well.